### PR TITLE
Integration of multiGPU training

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,10 @@
-Version 0.2.0: (master)
+Version 0.2.1: (master)
 
+
+Version 0.2.0:
+    Adding multiGPU training with the integration of the horovod library, which handles the communication between the GPU or machines.
+        
+    Adding a dockerfile for installing the horovod since it can be a hassle to install horovod with the correct dependencies
     
 
 Version 0.1.9:

--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -1,0 +1,73 @@
+ARG CUDA_DOCKER_VERSION=11.4.2-devel-ubuntu18.04
+FROM nvidia/cuda:${CUDA_DOCKER_VERSION}
+
+ARG TENSORFLOW_VERSION=2.8.0
+ARG CUDNN_VERSION=8.2.4.15-1+cuda11.4
+ARG NCCL_VERSION=2.11.4-1+cuda11.4
+ARG HOROVOD_VERSION=0.24.2
+ARG PYTHON_VERSION=3.8
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
+
+RUN apt-get update && apt-get install -y --allow-downgrades --allow-change-held-packages --no-install-recommends \
+        build-essential \
+        cmake \
+        g++-7 \
+        git \
+        curl \
+        vim \
+        wget \
+        ca-certificates \
+        libcudnn8=${CUDNN_VERSION} \
+        libnccl2=2.11.4-1+cuda11.4 \
+        libnccl-dev=2.11.4-1+cuda11.4 \
+        libjpeg-dev \
+        libpng-dev \
+        python${PYTHON_VERSION} \
+        python${PYTHON_VERSION}-dev \
+        python${PYTHON_VERSION}-distutils \
+        librdmacm1 \
+        libibverbs1 \
+        ibverbs-providers \
+        openjdk-8-jdk-headless \
+        openssh-client \
+        openssh-server \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+RUN wget --progress=dot:mega -O /tmp/openmpi-3.0.0-bin.tar.gz https://github.com/horovod/horovod/files/1596799/openmpi-3.0.0-bin.tar.gz && \
+    cd /usr/local && \
+    tar -zxf /tmp/openmpi-3.0.0-bin.tar.gz && \
+    ldconfig && \
+    mpirun --version
+
+RUN mkdir -p /var/run/sshd
+RUN cat /etc/ssh/ssh_config | grep -v StrictHostKeyChecking > /etc/ssh/ssh_config.new && \
+    echo "    StrictHostKeyChecking no" >> /etc/ssh/ssh_config.new && \
+    mv /etc/ssh/ssh_config.new /etc/ssh/ssh_config
+
+
+RUN ln -s /usr/bin/python${PYTHON_VERSION} /usr/bin/python
+
+RUN curl -O https://bootstrap.pypa.io/get-pip.py && \
+    python get-pip.py && \
+    rm get-pip.py && \
+    pip install --upgrade pip
+
+RUN pip install --no-cache-dir future typing packaging
+RUN pip install --no-cache-dir \
+    tensorflow==${TENSORFLOW_VERSION} \
+    h5py
+
+RUN ldconfig /usr/local/cuda/targets/x86_64-linux/lib/stubs && \
+    bash -c "HOROVOD_GPU_OPERATIONS=NCCL HOROVOD_WITH_TENSORFLOW=1 HOROVOD_WITHOUT_PYTORCH=1 HOROVOD_WITHOUT_MXNET=1 pip install --no-cache-dir horovod==${HOROVOD_VERSION}" && \
+    horovodrun --check-build && \
+    ldconfig
+
+WORKDIR /polus
+COPY . .
+RUN pip install -r requirements.txt && \
+    python setup.py bdist_wheel && \
+    pip install dist/polus-0.1.9-py3-none-any.whl
+

--- a/polus/__init__.py
+++ b/polus/__init__.py
@@ -51,7 +51,7 @@ enabled by default, which can be easily accessed by the polus.core API.
 
 '''
 
-__version__="0.1.9"
+__version__="0.2.0"
 import tensorflow as tf
 
 try:

--- a/polus/__init__.py
+++ b/polus/__init__.py
@@ -77,7 +77,8 @@ class PolusContext(metaclass=Singleton):
                     print(f"The script found multiple GPUs and a horovod.tensorlfow installation. However,"
                                  f" the only one process was found, please check if you are runing the script with horovodrun.")
                 else:
-                    print(f"MultiGPU training enabled, using {hvd.size()} processes ")
+                    if hvd.local_rank() == 0:
+                        print(f"MultiGPU training enabled, using {hvd.size()} processes ")
                     self.use_horovod = True
 
             tf.config.experimental.set_visible_devices(gpus[hvd.local_rank()], 'GPU')

--- a/polus/__init__.py
+++ b/polus/__init__.py
@@ -52,6 +52,40 @@ enabled by default, which can be easily accessed by the polus.core API.
 '''
 
 __version__="0.1.9"
+import tensorflow as tf
+
+try:
+    import horovod.tensorflow as hvd
+except ModuleNotFoundError:
+    import polus.mock.horovod as hvd
+
+from polus.core import Singleton
+# init some vars
+class PolusContext(metaclass=Singleton):
+    
+    def __init__(self):
+        print("-----------------DEBUG INIT POLUS CONTEXT-------------")
+        self.use_horovod = False
+        gpus = tf.config.experimental.list_physical_devices('GPU')
+        if len(gpus) > 1:
+            if hvd.init() == "mock":
+                print(f"The script found multiple GPUs, however it cannot use them since multi-gpu"
+                                 f" requires horovod.tensorflow module to be installed.\n"
+                                 f"Intead the process will only use one")
+            else:
+                if hvd.size() <= 1:
+                    print(f"The script found multiple GPUs and a horovod.tensorlfow installation. However,"
+                                 f" the only one process was found, please check if you are runing the script with horovodrun.")
+                else:
+                    print(f"MultiGPU training enabled, using {hvd.size()} processes ")
+                    self.use_horovod = True
+
+            tf.config.experimental.set_visible_devices(gpus[hvd.local_rank()], 'GPU')
+            
+    def is_horovod_enabled(self):
+        return self.use_horovod
+        
+PolusContext()
 
 # add main lib sub packages
 #import polus.callbacks

--- a/polus/callbacks.py
+++ b/polus/callbacks.py
@@ -238,11 +238,16 @@ class ValidationDataCallback(Callback):
                 
                 ## down below only the root should the reminder of the code
                 ## THIS METHOD IS NOT EFFICIENT A MUCH MORE EFFECIENT GATHER_TO_ROOT method would be better
-                all_predictions = hvd.allgather_object(y)
                 
+                # Using tf.Tensor may be more performing, however, this should be a fairly low size data
+                #if isinstance(y, tf.Tensor):
+                #    all_predictions = hvd.allgather(y)
+                #else:
+                #    all_predictions = hvd.allgather_object(y)
+                all_predictions = hvd.allgather_object(y)
+
                 if hvd.local_rank() == 0:
                     for pred in all_predictions:
-                
                         for metric in self.coordinator.trainer.metrics:
                             metric.samples_from_batch(pred)
                             

--- a/polus/callbacks.py
+++ b/polus/callbacks.py
@@ -1,10 +1,12 @@
+
 from polus.core import BaseLogger, get_jit_compile
 from polus.models import PolusClassifier
 from polus.hpo import HPOContext
 
-try:
+from polus import PolusContext
+if PolusContext().is_horovod_enabled():
     import horovod.tensorflow as hvd
-except ModuleNotFoundError:
+else:
     import polus.mock.horovod as hvd
 
 from timeit import default_timer as timer

--- a/polus/core.py
+++ b/polus/core.py
@@ -31,6 +31,7 @@ import tensorflow as tf
 from logging.handlers import TimedRotatingFileHandler
 
 
+
 def set_jit_compile(mode: bool):
     """
     Changes the *jit_compile* attribute.
@@ -51,9 +52,9 @@ def get_jit_compile():
     """
     
     if os.environ.get("POLUS_JIT") is None:
-        set_jit_compile(True) # default mode
+        set_jit_compile(False) # default mode
     
-    return os.environ.get("POLUS_JIT")=="True"
+    return os.environ.get("POLUS_JIT")=="False"
 
 
 class Singleton(type):
@@ -215,3 +216,6 @@ def execute_if(condition_var, error_message="", on=True):
         return function_wrapper
     
     return decorator
+
+
+    

--- a/polus/core.py
+++ b/polus/core.py
@@ -54,7 +54,7 @@ def get_jit_compile():
     if os.environ.get("POLUS_JIT") is None:
         set_jit_compile(False) # default mode
     
-    return os.environ.get("POLUS_JIT")=="False"
+    return os.environ.get("POLUS_JIT")=="True"
 
 
 class Singleton(type):

--- a/polus/data.py
+++ b/polus/data.py
@@ -30,7 +30,7 @@ import pickle
 import random
 import json
 import inspect
-from polus import PolusContext
+
 from polus.core import BaseLogger, find_dtype_and_shapes
 from polus.models import split_bert_model
 import tensorflow as tf
@@ -39,9 +39,10 @@ from transformers.modeling_tf_outputs import TFBaseModelOutputWithPooling
 from functools import wraps
 from timeit import default_timer as timer
 
-try:
+from polus import PolusContext
+if PolusContext().is_horovod_enabled():
     import horovod.tensorflow as hvd
-except ModuleNotFoundError:
+else:
     import polus.mock.horovod as hvd
 
 class DataLoader(BaseLogger):

--- a/polus/data.py
+++ b/polus/data.py
@@ -30,6 +30,7 @@ import pickle
 import random
 import json
 import inspect
+from polus import PolusContext
 from polus.core import BaseLogger, find_dtype_and_shapes
 from polus.models import split_bert_model
 import tensorflow as tf
@@ -38,8 +39,10 @@ from transformers.modeling_tf_outputs import TFBaseModelOutputWithPooling
 from functools import wraps
 from timeit import default_timer as timer
 
-
-
+try:
+    import horovod.tensorflow as hvd
+except ModuleNotFoundError:
+    import polus.mock.horovod as hvd
 
 class DataLoader(BaseLogger):
     """
@@ -100,7 +103,11 @@ class DataLoader(BaseLogger):
         self.tf_dataset = tf.data.Dataset.from_generator(self.sample_generator, 
                                                          output_types= dytpes,
                                                          output_shapes= shapes)
-            
+        
+        if PolusContext().is_horovod_enabled():
+            print("----------SHARDING THE DATASET!!!!-----------")
+            self.tf_dataset = self.tf_dataset.shard(num_shards = hvd.size(), index=hvd.local_rank())
+        
         # expose all the tf dataset methods
         for method in filter(lambda x: not x[0].startswith("_"), inspect.getmembers(self.tf_dataset, predicate=inspect.ismethod)):
             setattr(self, method[0], method[1])

--- a/polus/mock/horovod.py
+++ b/polus/mock/horovod.py
@@ -1,0 +1,24 @@
+"""
+A mock file of the horovod module to just ignore its utilization
+"""
+
+def init():
+    return "mock"
+
+def local_rank():
+    """
+    Without a multi-gpu setup the local_rank is always 0
+    """
+    return 0
+
+def size():
+    return 1
+
+def DistributedGradientTape(tape):
+    return tape
+
+def broadcast_variables(variables, root_rank=0):
+    pass
+
+def allgather_object(y):
+    return [y]

--- a/polus_install.sh
+++ b/polus_install.sh
@@ -13,5 +13,5 @@ pip install -r requirements.txt
 
 python setup.py bdist_wheel
 
-pip install dist/polus-0.1.9-py3-none-any.whl
+pip install dist/polus-0.2.0-py3-none-any.whl
 cd -

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -3,11 +3,11 @@ import tensorflow as tf
 
 def test_jit_compile_flag():
     
-    assert get_jit_compile() == True
-    set_jit_compile(False)
     assert get_jit_compile() == False
     set_jit_compile(True)
     assert get_jit_compile() == True
+    set_jit_compile(False)
+    assert get_jit_compile() == False
     
 def test_singleton_pattern():
     

--- a/tutorials/classifier_example.py
+++ b/tutorials/classifier_example.py
@@ -31,13 +31,13 @@ def init_trainer():
         normalize_img, num_parallel_calls=tf.data.AUTOTUNE)
     ds_train = ds_train.cache()
     ds_train = ds_train.shuffle(len(x_train))
-    ds_train = ds_train.batch(128)
+    ds_train = ds_train.batch(128, drop_remainder=True)
     ds_train = ds_train.prefetch(tf.data.AUTOTUNE)
     
     ds_test = DataLoader(train_gen(x_test, y_test))
     ds_test = ds_test.map(
         normalize_img, num_parallel_calls=tf.data.AUTOTUNE)
-    ds_test = ds_test.batch(128, drop_remainder=True)
+    ds_test = ds_test.batch(128)
     ds_test = ds_test.cache()
     ds_test = ds_test.prefetch(tf.data.AUTOTUNE)
 


### PR DESCRIPTION
**TL;DR:** Every legacy training script will be compatible with the new multiGPU training

Integration of multiGPU (Data parallelism) training with **0** changes to the training script. 

This new mechanism leverages the [horovod ](https://github.com/horovod/horovod) library to distribute the work between processes, and it follows an MPI like API. 

Currently, to run on a multiGPU setup the [horovod.tensorflow](https://horovod.readthedocs.io/en/stable/api.html#module-horovod.tensorflow) package must be installed, if not the code will default to singleGPU.

Example of how to run on 2 GPUs using horovod:
`CUDA_VISIBLE_DEVICES="0,1" horovodrun -np 2 -H localhost:2 python tutorials/classifier_example.py`

For singleGPU just ignore the horovodrun script:
`CUDA_VISIBLE_DEVICES="0" python tutorials/classifier_example.py`

Note, that the same code is used, so by default, the code written for singleGPU should also work on multiGPU. Behind the scenes, Polus is handling the sharding of the dataset (among the processes), the distributed averaging of the gradients, the distributed initialization, the distributed execution of the validation callbacks (validation dataset is also distributed)...

